### PR TITLE
Issue#120 fix memory leak in busmap

### DIFF
--- a/src/main/java/no/difi/oxalis/as4/util/Constants.java
+++ b/src/main/java/no/difi/oxalis/as4/util/Constants.java
@@ -17,4 +17,8 @@ public class Constants {
 
     public static final String TEST_SERVICE = "http://docs.oasis-open.org/ebxml-msg/ebms/v3.0/ns/core/200704/service";
     public static final String TEST_ACTION = "http://docs.oasis-open.org/ebxml-msg/ebms/v3.0/ns/core/200704/test";
+
+    public static final String OXALIS_ALGORITHM_NAMESPACE = "http://oxalis.difi.no/custom/security-policy";
+    public static final String BASIC_128_GCM_SHA_256 = "Basic128GCMSha256";
+    public static final String BASIC_128_GCM_SHA_256_MGF_SHA_256 = "Basic128GCMSha256MgfSha256";
 }

--- a/src/main/java/no/difi/oxalis/as4/util/OxalisAlgorithmSuiteLoader.java
+++ b/src/main/java/no/difi/oxalis/as4/util/OxalisAlgorithmSuiteLoader.java
@@ -1,27 +1,20 @@
 package no.difi.oxalis.as4.util;
 
+import static no.difi.oxalis.as4.util.Constants.BASIC_128_GCM_SHA_256;
+import static no.difi.oxalis.as4.util.Constants.BASIC_128_GCM_SHA_256_MGF_SHA_256;
+import static no.difi.oxalis.as4.util.Constants.OXALIS_ALGORITHM_NAMESPACE;
+import static org.apache.wss4j.common.WSS4JConstants.MGF_SHA256;
+
 import lombok.extern.slf4j.Slf4j;
 import org.apache.cxf.Bus;
 import org.apache.cxf.ws.policy.AssertionBuilderRegistry;
-import org.apache.cxf.ws.policy.builder.primitive.PrimitiveAssertion;
-import org.apache.cxf.ws.policy.builder.primitive.PrimitiveAssertionBuilder;
 import org.apache.cxf.ws.security.policy.custom.AlgorithmSuiteLoader;
 import org.apache.neethi.Assertion;
-import org.apache.neethi.AssertionBuilderFactory;
 import org.apache.neethi.Policy;
-import org.apache.neethi.builders.xml.XMLPrimitiveAssertionBuilder;
 import org.apache.wss4j.common.WSS4JConstants;
 import org.apache.wss4j.policy.SPConstants;
 import org.apache.wss4j.policy.model.AbstractSecurityAssertion;
 import org.apache.wss4j.policy.model.AlgorithmSuite;
-import org.w3c.dom.Element;
-
-import javax.xml.namespace.QName;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
-import static org.apache.wss4j.common.WSS4JConstants.MGF_SHA256;
 
 
 // Based on from CEF e-delivery Domibus
@@ -29,27 +22,11 @@ import static org.apache.wss4j.common.WSS4JConstants.MGF_SHA256;
 @Slf4j
 public class OxalisAlgorithmSuiteLoader implements AlgorithmSuiteLoader {
 
-    public static final String OXALIS_ALGORITHM_NAMESPACE = "http://oxalis.difi.no/custom/security-policy";
     public static final String AES128_GCM_ALGORITHM = "http://www.w3.org/2009/xmlenc11#aes128-gcm";
-    public static final String BASIC_128_GCM_SHA_256 = "Basic128GCMSha256";
-    public static final String BASIC_128_GCM_SHA_256_MGF_SHA_256 = "Basic128GCMSha256MgfSha256";
-
-    private static final Map<String, Bus> BUS_MAP = new ConcurrentHashMap<>();
 
     public OxalisAlgorithmSuiteLoader(final Bus bus) {
-        BUS_MAP.computeIfAbsent(bus.getId(), id -> {
-            AlgorithmSuiteLoader algorithmSuiteLoader = bus.getExtension(AlgorithmSuiteLoader.class);
-
-            if (algorithmSuiteLoader instanceof OxalisAlgorithmSuiteLoader) {
-                log.info("Cached OxalisAlgorithmSuite on bus {}", bus.getId());
-            } else {
-                log.info("Registering OxalisAlgorithmSuite on bus {}", bus.getId());
-                bus.setExtension(this, AlgorithmSuiteLoader.class);
-                register(bus);
-            }
-
-            return bus;
-        });
+        bus.setExtension(this, AlgorithmSuiteLoader.class);
+        register(bus);
     }
 
     public AlgorithmSuite getAlgorithmSuite(final Bus bus, final SPConstants.SPVersion version, final Policy nestedPolicy) {
@@ -59,23 +36,7 @@ public class OxalisAlgorithmSuiteLoader implements AlgorithmSuiteLoader {
     private void register(final Bus bus) {
         final AssertionBuilderRegistry reg = bus.getExtension(AssertionBuilderRegistry.class);
         if (reg != null) {
-            final Map<QName, Assertion> assertions = new HashMap<>();
-            QName qName = new QName(OXALIS_ALGORITHM_NAMESPACE, BASIC_128_GCM_SHA_256);
-            assertions.put(qName, new PrimitiveAssertion(qName));
-            qName = new QName(OXALIS_ALGORITHM_NAMESPACE, BASIC_128_GCM_SHA_256_MGF_SHA_256);
-            assertions.put(qName, new PrimitiveAssertion(qName));
-
-            reg.registerBuilder(new PrimitiveAssertionBuilder(assertions.keySet()) {
-                @Override
-                public Assertion build(final Element element, final AssertionBuilderFactory fact) {
-                    if (XMLPrimitiveAssertionBuilder.isOptional(element)
-                            || XMLPrimitiveAssertionBuilder.isIgnorable(element)) {
-                        return super.build(element, fact);
-                    }
-                    final QName q = new QName(element.getNamespaceURI(), element.getLocalName());
-                    return assertions.get(q);
-                }
-            });
+            reg.registerBuilder(new OxalisAssertionBuilder());
         }
     }
 
@@ -127,7 +88,7 @@ public class OxalisAlgorithmSuiteLoader implements AlgorithmSuiteLoader {
         protected void parseCustomAssertion(final Assertion assertion) {
             final String assertionName = assertion.getName().getLocalPart();
             final String assertionNamespace = assertion.getName().getNamespaceURI();
-            if (!OxalisAlgorithmSuiteLoader.OXALIS_ALGORITHM_NAMESPACE.equals(assertionNamespace)) {
+            if (!OXALIS_ALGORITHM_NAMESPACE.equals(assertionNamespace)) {
                 return;
             }
 

--- a/src/main/java/no/difi/oxalis/as4/util/OxalisAssertionBuilder.java
+++ b/src/main/java/no/difi/oxalis/as4/util/OxalisAssertionBuilder.java
@@ -1,0 +1,41 @@
+package no.difi.oxalis.as4.util;
+
+import static no.difi.oxalis.as4.util.Constants.BASIC_128_GCM_SHA_256;
+import static no.difi.oxalis.as4.util.Constants.BASIC_128_GCM_SHA_256_MGF_SHA_256;
+import static no.difi.oxalis.as4.util.Constants.OXALIS_ALGORITHM_NAMESPACE;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.xml.namespace.QName;
+
+import org.apache.cxf.ws.policy.builder.primitive.PrimitiveAssertion;
+import org.apache.cxf.ws.policy.builder.primitive.PrimitiveAssertionBuilder;
+import org.apache.neethi.Assertion;
+import org.apache.neethi.AssertionBuilderFactory;
+import org.apache.neethi.builders.xml.XMLPrimitiveAssertionBuilder;
+import org.w3c.dom.Element;
+
+
+/**
+ * @author Jonas Hysing Øvrebø (pearl consulting)
+ */
+public class OxalisAssertionBuilder extends PrimitiveAssertionBuilder {
+	private static final Map<QName, Assertion> ASSERTION_MAP = new HashMap<>(2);
+	static {
+		final QName basic128GCMSha256QName = new QName(OXALIS_ALGORITHM_NAMESPACE, BASIC_128_GCM_SHA_256);
+		final QName basic128GCMSha256MgfSha256QName = new QName(OXALIS_ALGORITHM_NAMESPACE, BASIC_128_GCM_SHA_256_MGF_SHA_256);
+
+		ASSERTION_MAP.put(basic128GCMSha256QName, new PrimitiveAssertion(basic128GCMSha256QName));
+		ASSERTION_MAP.put(basic128GCMSha256MgfSha256QName, new PrimitiveAssertion(basic128GCMSha256MgfSha256QName));
+	}
+
+	@Override
+	public Assertion build(final Element element, final AssertionBuilderFactory fact) {
+		if (XMLPrimitiveAssertionBuilder.isOptional(element) || XMLPrimitiveAssertionBuilder.isIgnorable(element)) {
+			return super.build(element, fact);
+		}
+		final QName q = new QName(element.getNamespaceURI(), element.getLocalName());
+		return ASSERTION_MAP.get(q);
+	}
+}


### PR DESCRIPTION
Avoids adding a new entry to the map for each unique id.
Since every message has a unique id and the map static, this quickly causes memory issues.