### PR TITLE
Upgrade CXF to latest version to get rid of CVE-2022-46364 and

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,8 +97,8 @@
 
         <peppol.sbdh.version>1.0.0</peppol.sbdh.version>
 
-        <cxf.version>3.3.8</cxf.version>
-        <wss4j.version>2.2.7</wss4j.version>
+        <cxf.version>3.5.5</cxf.version>
+        <wss4j.version>2.4.1</wss4j.version>
         <neethi.version>3.2.0</neethi.version>
         <soap.version>1.4.0</soap.version>
 

--- a/src/main/java/network/oxalis/as4/util/OxalisAlgorithmSuiteLoader.java
+++ b/src/main/java/network/oxalis/as4/util/OxalisAlgorithmSuiteLoader.java
@@ -70,6 +70,8 @@ public class OxalisAlgorithmSuiteLoader implements AlgorithmSuiteLoader {
                             128, 128, 128, 256, 1024, 4096
                     )
             );
+            ALGORITHM_SUITE_TYPES.get(BASIC_128_GCM_SHA_256)
+                .setAsymmetricSignature("http://www.w3.org/2001/04/xmldsig-more#rsa-sha256");
             AlgorithmSuiteType algorithmSuiteType = ALGORITHM_SUITE_TYPES.get(BASIC_128_GCM_SHA_256_MGF_SHA_256);
             algorithmSuiteType.setMGFAlgo(MGF_SHA256);
             algorithmSuiteType.setEncryptionDigest(SPConstants.SHA256);

--- a/src/main/java/network/oxalis/as4/util/OxalisAlgorithmSuiteLoader.java
+++ b/src/main/java/network/oxalis/as4/util/OxalisAlgorithmSuiteLoader.java
@@ -70,13 +70,14 @@ public class OxalisAlgorithmSuiteLoader implements AlgorithmSuiteLoader {
                             128, 128, 128, 256, 1024, 4096
                     )
             );
-            ALGORITHM_SUITE_TYPES.get(BASIC_128_GCM_SHA_256_MGF_SHA_256).setMGFAlgo(MGF_SHA256);
-            ALGORITHM_SUITE_TYPES.get(BASIC_128_GCM_SHA_256_MGF_SHA_256).setEncryptionDigest(SPConstants.SHA256);
+            AlgorithmSuiteType algorithmSuiteType = ALGORITHM_SUITE_TYPES.get(BASIC_128_GCM_SHA_256_MGF_SHA_256);
+            algorithmSuiteType.setMGFAlgo(MGF_SHA256);
+            algorithmSuiteType.setEncryptionDigest(SPConstants.SHA256);
+            algorithmSuiteType.setAsymmetricSignature("http://www.w3.org/2001/04/xmldsig-more#rsa-sha256");
         }
 
         OxalisAlgorithmSuite(final SPConstants.SPVersion version, final Policy nestedPolicy) {
             super(version, nestedPolicy);
-            this.setAsymmetricSignature("http://www.w3.org/2001/04/xmldsig-more#rsa-sha256");
         }
 
         @Override


### PR DESCRIPTION
CVE-2022-46363

Also upgrade WSS4J to 2.4.1 which is supposed to work with CXF >= 3.4.*.

## Pull Request Description

Fixes the above two vulnerabilities being reported against Oxalis-AS4 5.4.0 by snyk and Trivy.
I have barely tested a snapshot of it with Oxalis 5.4.0 in a test environment at Digipost (both inbound and outbound processes), but haven't found any isses so far.

Not 100% sure yet if the upgrade breaks anything else. 

## Type of Pull Request

- [ ] New feature/Enhancement - non-breaking change which adds functionality
- [X] Bug fix 
- [ ] Breaking change (Require Major version change?)

## Type of Change

- [ ] OpenPeppol AS4 specification
- [X] Oxalis software change or enhancement
- [ ] CEF change

## Pull Request Checklist:

- [X] My code follows the style guidelines of this project
- [NA] I have commented my code, particularly in hard-to-understand areas. But did not added unnecessary annotation/comment say @author name etc
- [X] I have checked my code for variable and method name and corrected grammar/spelling mistakes if any
- [NA] I have made corresponding changes to the documentation where needed
- [X] My changes generate no new/additional warnings
- [?] My change is not breaking or creating conflict with associated dependencies 
- [X] I have performed a self-review of my own code
- [X] I ran `mvn clean install` before commit and all tests run successfully 
- [X] I conducted basic QA to assure all features are working fine
- [X] My pull request generate no conflicts with `master` branch
- [X] I requested code review from other team members
